### PR TITLE
Apply error mechanisms per column, not globally

### DIFF
--- a/error_generation/api/low_level.py
+++ b/error_generation/api/low_level.py
@@ -11,19 +11,24 @@ if TYPE_CHECKING:
     from error_generation.error_type import ErrorType
 
 
-def create_errors(table: pd.DataFrame, column: str | int, error_mechanism: ErrorMechanism, error_type: ErrorType) -> tuple[pd.DataFrame, pd.DataFrame]:
+def create_errors(
+    table: pd.DataFrame, column: str | int, error_rate: float, error_mechanism: ErrorMechanism, error_type: ErrorType
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Creates errors in a given column of a pandas DataFrame.
 
     Args:
         table: The pandas DataFrame to create errors in.
         column: The column to create errors in.
+        error_rate: The rate at which errors will be created.
         error_mechanism: The mechanism, controls the error distribution.
         error_type: The type of the error that will be distributed.
 
     Returns:
-        A tuple of the original DataFrame and the error mask.
+        A tuple of a copy of the DataFrame with errors, and the error mask.
     """
-    error_mask = error_mechanism.sample(table, seed=None)
-    series = error_type.apply(table, error_mask, column)
-    set_column(table, column, series)
-    return table, error_mask
+    table_copy = table.copy()
+
+    error_mask = error_mechanism.sample(table_copy, column, error_rate, error_mask=None)
+    series = error_type.apply(table_copy, error_mask, column)
+    set_column(table_copy, column, series)
+    return table_copy, error_mask

--- a/error_generation/error_mechanism/_ear.py
+++ b/error_generation/error_mechanism/_ear.py
@@ -4,53 +4,41 @@ import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
-import pandas as pd
+
+from error_generation.utils import get_column, get_column_str
+
+from ._base import ErrorMechanism
 
 if TYPE_CHECKING:
-    from pandas._typing import Dtype
-from ._base import ErrorMechanism
+    import pandas as pd
 
 
 class EAR(ErrorMechanism):
-    @staticmethod
-    def _sample(data: pd.DataFrame, error_rate: float, condition_to_column: Dtype | None = None, seed: int | None = None) -> pd.DataFrame:
+    def _sample(self: EAR, data: pd.DataFrame, column: str | int, error_rate: float, error_mask: pd.DataFrame) -> pd.DataFrame:
         if len(data.columns) < 2:  # noqa: PLR2004
-            msg = "'data' need at least 2 columns."
+            msg = "The table into which error at random (EAR) are to be injected requies at least 2 columns."
             raise ValueError(msg)
 
-        if condition_to_column is None:
-            condition_to_column = np.random.default_rng(seed).choice(data.columns)
-
-        # NOTE: We do not perturb the 'condition_to_column' column, so we need to handle the following edge case:
-        # If 'columns_to_create_errors' don't have enough cells to reach 'error_rate',
-        # we simply perturb as many as possible, i.e., all cells in 'columns_to_create_errors'
-        columns_to_create_errors = data.columns.drop(condition_to_column)
-        if error_rate >= len(columns_to_create_errors) / len(data.columns):
+        if self.condition_to_column is None:
+            col = get_column_str(data, column)
+            column_selection = [x for x in data.columns if x != col]
+            condition_to_column = np.random.default_rng(self.seed).choice(column_selection)
             warnings.warn(
-                "Given 'error_rate' can not be fulfilled because EAR does not perturb the 'condition_to_column'. Will perturb as many cells as possible.",
+                "The user did not specify 'condition_to_column', the column on which the EAR Mechanism conditions the error distribution. "
+                f"Randomly select {condition_to_column}.",
                 stacklevel=1,
             )
-            is_error_rate_too_large = True
-            how_many_error_cells_for_each_column = len(data)
-
         else:
-            is_error_rate_too_large = False
-            how_many_error_cells_for_each_column = int(data.size * error_rate / len(columns_to_create_errors))
+            condition_to_column = get_column_str(data, self.condition_to_column)
 
-        error_mask = pd.DataFrame(data=False, index=data.index, columns=data.columns)
+        se_data = get_column(data, column)
+        se_mask = get_column(error_mask, column)
+        n_errors = int(se_data.size * error_rate)
 
-        # distribute errors equally over all columns but not 'condition_to_column'
-        for column in columns_to_create_errors:
-            lower_error_index = np.random.default_rng(seed).integers(
-                0,
-                1 if is_error_rate_too_large else len(data) - how_many_error_cells_for_each_column,
-            )
-            error_index_range = range(lower_error_index, lower_error_index + how_many_error_cells_for_each_column)
+        upper_bound = len(se_data) - n_errors
+        lower_error_index = np.random.default_rng(self.seed).integers(0, upper_bound) if upper_bound > 0 else 0
+        error_index_range = range(lower_error_index, lower_error_index + n_errors)
 
-            error_mask.loc[data.sort_values(by=condition_to_column).index[error_index_range], column] = True
-
-            # avoid sample same indices for each column
-            if isinstance(seed, int):
-                seed += 1
+        se_mask.loc[data.sort_values(by=condition_to_column).index[error_index_range]] = True
 
         return error_mask

--- a/error_generation/error_type/__init__.py
+++ b/error_generation/error_type/__init__.py
@@ -2,6 +2,7 @@ from ._base import ErrorType
 from .butterfinger import Butterfinger
 from .mislabel import Mislabel
 from .missing import MissingValue
+from .mistype import Mistype
 from .mojibake import Mojibake
 from .permutate import Permutate
 from .wrong_unit import WrongUnit

--- a/error_generation/utils/__init__.py
+++ b/error_generation/utils/__init__.py
@@ -1,1 +1,1 @@
-from .utils import ErrorTypeConfig, get_column, set_column
+from .utils import ErrorTypeConfig, MidLevelConfig, get_column, get_column_str, set_column

--- a/samples.ipynb
+++ b/samples.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 151,
    "id": "a06b4cd8-6bd2-4321-a4ac-2beea45d67db",
    "metadata": {},
    "outputs": [
@@ -21,35 +21,510 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "74855e3b-472f-4d3f-834b-adb36adc0419",
-   "metadata": {},
-   "source": [
-    "# Use `low_level` API to create `Mojibake` in one column"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 46,
-   "id": "3b62f455-52b2-474b-9ba0-ba4d24e56ae1",
+   "execution_count": 181,
+   "id": "ee5a7b2d-55ad-48de-ad8f-94248cdd542b",
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
     "from error_generation.api.low_level import create_errors\n",
-    "from error_generation.error_mechanism import ECAR\n",
-    "from error_generation.error_type import Butterfinger, Mislabel, MissingValue, Mojibake, Permutate, WrongUnit"
+    "from error_generation.error_mechanism import EAR, ECAR, ENAR\n",
+    "from error_generation.error_type import Butterfinger, Mislabel, MissingValue, Mistype, Mojibake, Permutate, WrongUnit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d844adb-dbf8-44e3-89ce-deb51d19ce30",
+   "metadata": {},
+   "source": [
+    "# Error Generation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d52ec07-7a50-49b2-abd0-03e8c7b6c614",
+   "metadata": {},
+   "source": [
+    "The following notebook demonstrates how the `error_generation` software package functions.\n",
+    "Fundamentally, one Error Mechanism and one Error Type are combined into an Error Model, which we need to insert errors into tables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f4f8652-b864-4396-b9ec-71d72bd9156d",
+   "metadata": {},
+   "source": [
+    "## Error Mechanism\n",
+    "The Error Mechanism determines the distribution of errors. \n",
+    "We distinguish between Erroenous Not At Random (ENAR), Erroneous At Random (EAR) and Erroneous Completely At Random (ECAR)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ca482b7-bade-4e2d-9c67-81c40a4ebbb3",
+   "metadata": {},
+   "source": [
+    "### Erroneous Not At Random (ENAR)\n",
+    "The distribution of errors that are ENAR depends on the erroneous value itself: For example, imagine three services write data into one table. \n",
+    "The table's schema contains a column `service`, into which the services write their name and the date when inserting a value, following the format `${SERVICE}-YYYY-MM-DD`.\n",
+    "Now, imagine that one of the services uses the incorrect format `${SERICE}-DD-MM-YYYY`.\n",
+    "In this scenario, the distribution of the error depends on the erroneous value.\n",
+    "\n",
+    "Let's go ahead and simulate it using `error_generation`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
-   "id": "f09057a2-ae58-4012-bd4a-82b678aabfa0",
+   "execution_count": 182,
+   "id": "e4cea319-2cce-4639-8b1e-aa9a8f8d5fdd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ecar = ECAR(error_rate=1.0)"
+    "df_enar = pd.DataFrame(\n",
+    "    {\n",
+    "        \"service\": [\n",
+    "            \"Aservice-2024-02-01\",\n",
+    "            \"Aservice-2024-02-02\",\n",
+    "            \"Aservice-2024-02-03\",\n",
+    "            \"Bservice-2024-02-01\",\n",
+    "            \"Bservice-2024-02-02\",\n",
+    "            \"Bservice-2024-02-03\",\n",
+    "            \"Cservice-2024-02-01\",\n",
+    "            \"Cservice-2024-02-02\",\n",
+    "            \"Cservice-2024-02-03\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "enar, permutate = ENAR(), Permutate({\"permutation_separator\": \"-\", \"permutation_pattern\": [0, 3, 2, 1]})\n",
+    "\n",
+    "df_corrupted, error_mask = create_errors(df_enar, \"service\", 0.34, enar, permutate)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 183,
+   "id": "146a23a0-226f-4099-bb74-bd98a8796143",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>service</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Aservice-01-02-2024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Aservice-02-02-2024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Aservice-03-02-2024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Bservice-2024-02-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bservice-2024-02-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Bservice-2024-02-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Cservice-2024-02-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Cservice-2024-02-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Cservice-2024-02-03</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               service\n",
+       "0  Aservice-01-02-2024\n",
+       "1  Aservice-02-02-2024\n",
+       "2  Aservice-03-02-2024\n",
+       "3  Bservice-2024-02-01\n",
+       "4  Bservice-2024-02-02\n",
+       "5  Bservice-2024-02-03\n",
+       "6  Cservice-2024-02-01\n",
+       "7  Cservice-2024-02-02\n",
+       "8  Cservice-2024-02-03"
+      ]
+     },
+     "execution_count": 183,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_corrupted"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8b346ee-0c25-4f5e-a742-93b49f46a596",
+   "metadata": {},
+   "source": [
+    "### Erroneous At Random (EAR)\n",
+    "In case the distribution of errors in one column depends on the distribution of another column, we call the the error distribution EAR. For example, imagine several typists manually digitizing a table. One of the typists might make errors while typing. Let's simulate this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "id": "0ef70d60-cf62-4b66-856d-43db6f4a9378",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/philipp/code/error-generation/error_generation/error_mechanism/_ear.py:26: UserWarning: The user did not specify 'condition_to_column', the column on which the EAR Mechanism conditions the error distribution. Randomly select typist.\n",
+      "  raise ValueError(msg)\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_ear = pd.DataFrame(\n",
+    "    {\n",
+    "        \"typist\": [\"Alice\", \"Alice\", \"Alice\", \"Bob\", \"Bob\", \"Bob\"],\n",
+    "        \"book_title\": [\"To Kill a Mockingbird\", \"1984\", \"Pride and Prejudice\", \"The Great Gatsby\", \"Moby-Dick\", \"The Catcher in the Rye\"],\n",
+    "    }\n",
+    ")\n",
+    "ear, butterfinger = EAR(), Butterfinger()\n",
+    "\n",
+    "df_corrupted, error_mask = create_errors(df_ear, \"book_title\", 0.5, ear, butterfinger)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
+   "id": "bd456d16-a8cb-4a3d-b496-35c755fd25ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>typist</th>\n",
+       "      <th>book_title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Alice</td>\n",
+       "      <td>To Kill s Mockingbird</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Alice</td>\n",
+       "      <td>q984</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Alice</td>\n",
+       "      <td>Pride and Prejhdice</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Bob</td>\n",
+       "      <td>The Great Gatsby</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bob</td>\n",
+       "      <td>Moby-Dick</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Bob</td>\n",
+       "      <td>The Catcher in the Rye</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  typist              book_title\n",
+       "0  Alice   To Kill s Mockingbird\n",
+       "1  Alice                    q984\n",
+       "2  Alice     Pride and Prejhdice\n",
+       "3    Bob        The Great Gatsby\n",
+       "4    Bob               Moby-Dick\n",
+       "5    Bob  The Catcher in the Rye"
+      ]
+     },
+     "execution_count": 185,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_corrupted"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1e4413e-edc1-4e8d-bb22-e4c0b5790ff6",
+   "metadata": {},
+   "source": [
+    "### Erroneous Completely At Random (ECAR)\n",
+    "In case the distribution of errors does not depend on the erroneous column or any other column in the table, we call the distribution ECAR. For example, imagine a table containing application data. Depending on the device and software utilized by the application's users, the user's content contains encoding errors. Because the table does not include information on the device or software, the errors appear completely at random. We can use `error_generation` to simulate this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 186,
+   "id": "cb40305c-daaa-42fc-bf90-64d4f6d7861d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_ecar = pd.DataFrame(\n",
+    "    {\n",
+    "        \"user\": [\"Alice\", \"Alice\", \"Bob\", \"Bob\", \"Clara\", \"David\"],\n",
+    "        \"content\": [\"¿Cómo estás?\", \"Привет, как дела?\", \"今日はどうですか\", \"Ça va bien, merci.\", \"¡Nos vemos mañana!\", \"Ich hätte Hunger.\"],\n",
+    "    }\n",
+    ")\n",
+    "ecar, mojibake = ECAR(), Mojibake({\"encoding_sender\": \"utf-8\", \"encoding_receiver\": \"iso-8859-1\"})\n",
+    "\n",
+    "df_corrupted, error_mask = create_errors(df_ecar, \"content\", 0.5, ecar, mojibake)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 187,
+   "id": "41464b03-b38c-4607-92cd-59165d01965d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>user</th>\n",
+       "      <th>content</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Alice</td>\n",
+       "      <td>Â¿CÃ³mo estÃ¡s?</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Alice</td>\n",
+       "      <td>ÐÑÐ¸Ð²ÐµÑ, ÐºÐ°Ðº Ð´ÐµÐ»Ð°?</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Bob</td>\n",
+       "      <td>今日はどうですか</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Bob</td>\n",
+       "      <td>Ça va bien, merci.</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Clara</td>\n",
+       "      <td>¡Nos vemos mañana!</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>David</td>\n",
+       "      <td>Ich hÃ¤tte Hunger.</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    user                         content\n",
+       "0  Alice                 Â¿CÃ³mo estÃ¡s?\n",
+       "1  Alice  ÐÑÐ¸Ð²ÐµÑ, ÐºÐ°Ðº Ð´ÐµÐ»Ð°?\n",
+       "2    Bob                        今日はどうですか\n",
+       "3    Bob              Ça va bien, merci.\n",
+       "4  Clara              ¡Nos vemos mañana!\n",
+       "5  David              Ich hÃ¤tte Hunger."
+      ]
+     },
+     "execution_count": 187,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_corrupted"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74855e3b-472f-4d3f-834b-adb36adc0419",
+   "metadata": {},
+   "source": [
+    "## Error Type\n",
+    "The Error Type corresponds to the Error Mechanism: Where the Error Mechanism indicates if a cell contains an error, the Error Type defines how the correct value will be transformed into the error.\n",
+    "\n",
+    "Below, we demonstrate the different Error Types."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed7fa65b-e6d8-4c49-8501-a88165a01472",
+   "metadata": {},
+   "source": [
+    "## Mistype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
+   "id": "98633b5e-957c-4f2b-813f-208fbed6d855",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mistype = Mistype({\"mistype_dtype\": \"float64\"})\n",
+    "ecar = ECAR()\n",
+    "df_mistype = pd.DataFrame({\"a\": [1, 2, 3], \"b\": [\"blau\", \"gelb\", \"blau\"]})\n",
+    "df_corrupted, error_mask = create_errors(df_mistype, \"a\", 0.5, ecar, mistype)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "id": "a7d421e5-1103-4cde-849b-adb689043081",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>blau</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>gelb</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>blau</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     a     b\n",
+       "0  1.0  blau\n",
+       "1    2  gelb\n",
+       "2    3  blau"
+      ]
+     },
+     "execution_count": 163,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_corrupted"
    ]
   },
   {
@@ -62,38 +537,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 169,
    "id": "dff2611e-b16b-4104-ba1d-4696a18c8330",
    "metadata": {},
    "outputs": [],
    "source": [
     "data = {\"A\": [\"apple\", \"banana\", \"cherry\", \"pineapple\"], \"B\": [\"red apple\", \"yellow banana\", \"dark cherry\", \"blue pineapple\"], \"C\": [10, 20, 30, 40]}\n",
-    "df_permutate = pd.DataFrame(data)"
+    "df_permutate = pd.DataFrame(data)\n",
+    "permutate = Permutate({\"permutation_separator\": \" \", \"permutation_automation_pattern\": \"fixed\"})\n",
+    "df_corrupted, error_mask = create_errors(df_permutate, \"B\", 1.0, ecar, permutate)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
-   "id": "16529889-cc14-48ae-914a-53a99b1ed676",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "permutate = Permutate({\"permutation_separator\": \" \", \"permutation_pattern\": \"fixed\"})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "id": "9b399f77-83da-470f-910b-5b161566577a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_corrupted, error_mask = create_errors(df_permutate, \"B\", ecar, permutate)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 170,
    "id": "1221cb45-2f54-4167-8ebb-26b4f6723555",
    "metadata": {},
    "outputs": [
@@ -160,7 +617,7 @@
        "3  pineapple  pineapple blue  40"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 170,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -179,37 +636,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 171,
    "id": "92c3a871-3078-4552-b9e6-d583e36e2ec2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mojibake = Mojibake()"
+    "mojibake = Mojibake()\n",
+    "df_mojibake = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [\"Ente\", \"Haus\", \"Grünfelder Straße 17, 13357 Öppeln\"]})\n",
+    "df_corrupted, error_mask = create_errors(df_mojibake, \"b\", 1.0, ecar, mojibake)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "id": "3e705b44-36c4-459b-ba78-55ab83fbbb68",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_mojibake = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [\"Ente\", \"Haus\", \"Grünfelder Straße 17, 13357 Öppeln\"]})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "id": "11c576a2-1cd1-4fad-829e-bc036230051c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_corrupted, error_mask = create_errors(df_mojibake, \"b\", ecar, mojibake)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 172,
    "id": "288759e4-f634-49d6-a285-deb0e0abf999",
    "metadata": {},
    "outputs": [
@@ -265,7 +704,7 @@
        "2  2  Grnfelder Strae 17, 13357 ppeln"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 172,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -284,37 +723,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 173,
    "id": "8f5fa21b-0af8-43ae-9ac4-daa7c09c592a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "butterfinger = Butterfinger()"
+    "butterfinger = Butterfinger()\n",
+    "df_butterfinger = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [\"Entspannung\", \"Genugtuung\", \"Ausgeglichenheit\"]})\n",
+    "df_corrupted, error_mask = create_errors(df_butterfinger, \"b\", 1.0, ecar, butterfinger)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
-   "id": "1b5a2be4-671e-465b-bad2-469f9108bea6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_butterfinger = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [\"Entspannung\", \"Genugtuung\", \"Ausgeglichenheit\"]})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 104,
-   "id": "438a011a-6ff7-4428-91e9-df3cf5790323",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_corrupted, error_mask = create_errors(df_butterfinger, \"b\", ecar, butterfinger)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 174,
    "id": "5fb3f20d-8e30-47fa-aa8d-aeb541264b81",
    "metadata": {},
    "outputs": [
@@ -347,17 +768,17 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>0</td>\n",
-       "      <td>Entspannyng</td>\n",
+       "      <td>Entspannunh</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>1</td>\n",
-       "      <td>Genugyuung</td>\n",
+       "      <td>G3nugtuung</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>2</td>\n",
-       "      <td>Ausgeglichenhejt</td>\n",
+       "      <td>Qusgeglichenheit</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -365,12 +786,12 @@
       ],
       "text/plain": [
        "   a                 b\n",
-       "0  0       Entspannyng\n",
-       "1  1        Genugyuung\n",
-       "2  2  Ausgeglichenhejt"
+       "0  0       Entspannunh\n",
+       "1  1        G3nugtuung\n",
+       "2  2  Qusgeglichenheit"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 174,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -389,37 +810,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 175,
    "id": "53d9ebc6-7e12-4736-9734-babf114fa479",
    "metadata": {},
    "outputs": [],
    "source": [
-    "wrong_unit = WrongUnit({\"wrong_unit_scaling\": lambda x: x / 1000})"
+    "wrong_unit = WrongUnit({\"wrong_unit_scaling\": lambda x: x / 1000})\n",
+    "df_wrong_unit = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [40, 50, 60]})\n",
+    "df_corrupted, error_mask = create_errors(df_wrong_unit, 1, 1.0, ecar, wrong_unit)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
-   "id": "eac606df-8b0d-4e54-8d8a-89a0cf7f03f0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_wrong_unit = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [40, 50, 60]})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 99,
-   "id": "ac3689be-7d15-4b0a-9f2e-388e5fe4e449",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_corrupted, error_mask = create_errors(df_wrong_unit, 1, ecar, wrong_unit)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 176,
    "id": "656082b2-8cac-495a-aa59-eb662888cfc5",
    "metadata": {},
    "outputs": [
@@ -475,7 +878,7 @@
        "2  2  0.06"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 176,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -494,47 +897,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 177,
    "id": "6332c825-5cf3-421c-bb2e-f03cb55c34e6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mislabel = Mislabel()"
+    "mislabel = Mislabel()\n",
+    "df_mislabel = pd.DataFrame({\"a\": [1, 2, 3], \"b\": [\"blau\", \"gelb\", \"blau\"]})\n",
+    "df_mislabel[\"b\"] = df_mislabel[\"b\"].astype(\"category\")\n",
+    "df_corrupted, error_mask = create_errors(df_mislabel, \"b\", 1.0, ecar, mislabel)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
-   "id": "19228ba0-0f7f-49b5-b96e-25e0afddcce4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_mislabel = pd.DataFrame({\"a\": [1, 2, 3], \"b\": [\"blau\", \"gelb\", \"blau\"]})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 111,
-   "id": "cb8fb996-617f-45b5-9b05-da843c0e885f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_mislabel[\"b\"] = df_mislabel[\"b\"].astype(\"category\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 119,
-   "id": "a43eb3a6-4b34-4a59-b0b6-51acc0dce0d2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_corrupted, error_mask = create_errors(df_mislabel, \"b\", ecar, mislabel)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 178,
    "id": "8f064b77-b988-4c60-8363-42f93c90439c",
    "metadata": {},
    "outputs": [
@@ -590,7 +966,7 @@
        "2  3  gelb"
       ]
      },
-     "execution_count": 121,
+     "execution_count": 178,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -609,37 +985,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 179,
    "id": "5a0b6f34-6d5d-4e3a-9cd3-295fe2b0f1bd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "missing = MissingValue()"
+    "missing = MissingValue()\n",
+    "df_missing = pd.DataFrame({\"a\": [1, 2, 3], \"b\": [\"blau\", \"gelb\", \"blau\"]})\n",
+    "df_corrupted, error_mask = create_errors(df_missing, \"b\", 1.0, ecar, missing)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
-   "id": "2b34b853-1e34-4be3-9c24-9968c15a2931",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_missing = pd.DataFrame({\"a\": [1, 2, 3], \"b\": [\"blau\", \"gelb\", \"blau\"]})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 126,
-   "id": "bc9857c7-94c7-435c-8dc6-234d71669eca",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_corrupted, error_mask = create_errors(df_mislabel, \"b\", ecar, missing)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 180,
    "id": "73e37424-6433-42ce-b85e-58c5510c48c9",
    "metadata": {},
    "outputs": [
@@ -672,30 +1030,30 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>1</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>2</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>3</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   a    b\n",
-       "0  1  NaN\n",
-       "1  2  NaN\n",
-       "2  3  NaN"
+       "   a     b\n",
+       "0  1  None\n",
+       "1  2  None\n",
+       "2  3  None"
       ]
      },
-     "execution_count": 128,
+     "execution_count": 180,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Until this point, error mechanisms return an error mask that has the same dimensions as the entire dataframe. This is now improved, where each mechanism is applied to one column.

This allows in the long run to have complex scenarios, in which we iteratively have error mechanisms build the error mask - that will be handy for the mid-level API.

The commit changes the API a little bit.