### PR TITLE
Add Mid-Level API

### DIFF
--- a/error_generation/api/mid_level.py
+++ b/error_generation/api/mid_level.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from error_generation.utils import MidLevelConfig, set_column
+
+
+def create_errors(table: pd.DataFrame, config: MidLevelConfig) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Creates errors in a given DataFrame, following a user-defined configuration.
+
+    Args:
+        table: The pandas DataFrame to create errors in.
+        config: The configuration for the error generation process.
+
+    Returns:
+        A tuple of a copy of the DataFrame with errors, and the error mask.
+    """
+    table_dirty = table.copy()
+    error_mask = pd.DataFrame(data=False, index=table.index, columns=table.columns)
+
+    for column in config.columns:
+        for error_model in config.columns[column]:
+            error_mechanism = error_model.error_mechanism
+            error_type = error_model.error_type
+            error_rate = error_model.error_rate
+
+            old_error_mask = error_mask.copy()
+            error_mask = error_mechanism.sample(table, column, error_rate, error_mask)
+
+            series = error_type.apply(table, old_error_mask != error_mask, column)
+            set_column(table_dirty, column, series)
+    return table_dirty, error_mask

--- a/error_generation/error_mechanism/_ear.py
+++ b/error_generation/error_mechanism/_ear.py
@@ -25,7 +25,7 @@ class EAR(ErrorMechanism):
             condition_to_column = np.random.default_rng(self.seed).choice(column_selection)
             warnings.warn(
                 "The user did not specify 'condition_to_column', the column on which the EAR Mechanism conditions the error distribution. "
-                f"Randomly select {condition_to_column}.",
+                f"Randomly select column '{condition_to_column}'.",
                 stacklevel=1,
             )
         else:

--- a/error_generation/error_mechanism/_ecar.py
+++ b/error_generation/error_mechanism/_ecar.py
@@ -15,15 +15,22 @@ if TYPE_CHECKING:
 
 class ECAR(ErrorMechanism):
     def _sample(self: ECAR, data: pd.DataFrame, column: str | int, error_rate: float, error_mask: pd.DataFrame) -> pd.DataFrame:
-        se_data = get_column(data, column)
+        se_data = get_column(data, column)  # noqa: F841
         se_mask = get_column(error_mask, column)
+
+        se_mask_error_free = se_mask[~se_mask]
 
         if self.condition_to_column is not None:
             warnings.warn("'condition_to_column' is set but will be ignored by ECAR.", stacklevel=1)
 
-        n_errors = int(se_data.size * error_rate)
+        n_errors = int(se_mask.size * error_rate)
+
+        if len(se_mask_error_free) < n_errors:
+            msg = f"The error rate of {error_rate} requires {len(se_mask_error_free)} error-free cells. "
+            msg += f"However, only {len(se_mask_error_free)} error-free cells are available."
+            raise ValueError(msg)
 
         # randomly choose error-cells
-        error_indices = np.random.default_rng(seed=self.seed).choice(se_data.size, n_errors, replace=False)
+        error_indices = np.random.default_rng(seed=self.seed).choice(se_mask_error_free.index, n_errors, replace=False)
         se_mask[error_indices] = True
         return error_mask

--- a/error_generation/utils/__init__.py
+++ b/error_generation/utils/__init__.py
@@ -1,1 +1,1 @@
-from .utils import ErrorTypeConfig, MidLevelConfig, get_column, get_column_str, set_column
+from .utils import ErrorModel, ErrorTypeConfig, MidLevelConfig, get_column, get_column_str, set_column

--- a/error_generation/utils/utils.py
+++ b/error_generation/utils/utils.py
@@ -12,10 +12,11 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass
 class ErrorModel:
-    """An ErrorModel, which consists of an ErrorMechanism and an ErrorType."""
+    """An ErrorModel, which consists of an ErrorMechanis, an ErrorType, and an error rate."""
 
     error_mechanism: ErrorMechanism
     error_type: ErrorType
+    error_rate: float
 
 
 @dataclasses.dataclass
@@ -27,7 +28,7 @@ class MidLevelConfig:
     API.
     """
 
-    columns: dict[int | str, ErrorModel]
+    columns: dict[int | str, list[ErrorModel]]
 
 
 @dataclasses.dataclass

--- a/samples.ipynb
+++ b/samples.ipynb
@@ -2,19 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 1,
    "id": "a06b4cd8-6bd2-4321-a4ac-2beea45d67db",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -22,16 +13,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 25,
    "id": "ee5a7b2d-55ad-48de-ad8f-94248cdd542b",
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
-    "from error_generation.api.low_level import create_errors\n",
+    "from error_generation.api import low_level, mid_level\n",
     "from error_generation.error_mechanism import EAR, ECAR, ENAR\n",
-    "from error_generation.error_type import Butterfinger, Mislabel, MissingValue, Mistype, Mojibake, Permutate, WrongUnit"
+    "from error_generation.error_type import Butterfinger, Mislabel, MissingValue, Mistype, Mojibake, Permutate, WrongUnit\n",
+    "from error_generation.utils import ErrorModel, MidLevelConfig"
    ]
   },
   {
@@ -77,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 26,
    "id": "e4cea319-2cce-4639-8b1e-aa9a8f8d5fdd",
    "metadata": {},
    "outputs": [],
@@ -99,12 +91,12 @@
     ")\n",
     "enar, permutate = ENAR(), Permutate({\"permutation_separator\": \"-\", \"permutation_pattern\": [0, 3, 2, 1]})\n",
     "\n",
-    "df_corrupted, error_mask = create_errors(df_enar, \"service\", 0.34, enar, permutate)"
+    "df_corrupted, error_mask = low_level.create_errors(df_enar, \"service\", 0.34, enar, permutate)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 4,
    "id": "146a23a0-226f-4099-bb74-bd98a8796143",
    "metadata": {},
    "outputs": [
@@ -186,7 +178,7 @@
        "8  Cservice-2024-02-03"
       ]
      },
-     "execution_count": 183,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -206,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 27,
    "id": "0ef70d60-cf62-4b66-856d-43db6f4a9378",
    "metadata": {},
    "outputs": [
@@ -214,8 +206,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/philipp/code/error-generation/error_generation/error_mechanism/_ear.py:26: UserWarning: The user did not specify 'condition_to_column', the column on which the EAR Mechanism conditions the error distribution. Randomly select typist.\n",
-      "  raise ValueError(msg)\n"
+      "/Users/philipp/code/error-generation/error_generation/error_mechanism/_ear.py:26: UserWarning: The user did not specify 'condition_to_column', the column on which the EAR Mechanism conditions the error distribution. Randomly select column 'typist'.\n",
+      "  warnings.warn(\n"
      ]
     }
    ],
@@ -228,12 +220,12 @@
     ")\n",
     "ear, butterfinger = EAR(), Butterfinger()\n",
     "\n",
-    "df_corrupted, error_mask = create_errors(df_ear, \"book_title\", 0.5, ear, butterfinger)"
+    "df_corrupted, error_mask = low_level.create_errors(df_ear, \"book_title\", 0.5, ear, butterfinger)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 28,
    "id": "bd456d16-a8cb-4a3d-b496-35c755fd25ac",
    "metadata": {},
    "outputs": [
@@ -266,17 +258,17 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Alice</td>\n",
-       "      <td>To Kill s Mockingbird</td>\n",
+       "      <td>To Kill q Mockingbird</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Alice</td>\n",
-       "      <td>q984</td>\n",
+       "      <td>1983</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Alice</td>\n",
-       "      <td>Pride and Prejhdice</td>\n",
+       "      <td>Pride ans Prejudice</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -299,15 +291,15 @@
       ],
       "text/plain": [
        "  typist              book_title\n",
-       "0  Alice   To Kill s Mockingbird\n",
-       "1  Alice                    q984\n",
-       "2  Alice     Pride and Prejhdice\n",
+       "0  Alice   To Kill q Mockingbird\n",
+       "1  Alice                    1983\n",
+       "2  Alice     Pride ans Prejudice\n",
        "3    Bob        The Great Gatsby\n",
        "4    Bob               Moby-Dick\n",
        "5    Bob  The Catcher in the Rye"
       ]
      },
-     "execution_count": 185,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -327,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 29,
    "id": "cb40305c-daaa-42fc-bf90-64d4f6d7861d",
    "metadata": {},
    "outputs": [],
@@ -340,12 +332,12 @@
     ")\n",
     "ecar, mojibake = ECAR(), Mojibake({\"encoding_sender\": \"utf-8\", \"encoding_receiver\": \"iso-8859-1\"})\n",
     "\n",
-    "df_corrupted, error_mask = create_errors(df_ecar, \"content\", 0.5, ecar, mojibake)"
+    "df_corrupted, error_mask = low_level.create_errors(df_ecar, \"content\", 0.5, ecar, mojibake)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 30,
    "id": "41464b03-b38c-4607-92cd-59165d01965d",
    "metadata": {},
    "outputs": [
@@ -378,7 +370,7 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Alice</td>\n",
-       "      <td>Â¿CÃ³mo estÃ¡s?</td>\n",
+       "      <td>¿Cómo estás?</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -388,7 +380,7 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Bob</td>\n",
-       "      <td>今日はどうですか</td>\n",
+       "      <td>ä»æ¥ã¯ã©ãã§ãã</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -411,15 +403,15 @@
       ],
       "text/plain": [
        "    user                         content\n",
-       "0  Alice                 Â¿CÃ³mo estÃ¡s?\n",
+       "0  Alice                    ¿Cómo estás?\n",
        "1  Alice  ÐÑÐ¸Ð²ÐµÑ, ÐºÐ°Ðº Ð´ÐµÐ»Ð°?\n",
-       "2    Bob                        今日はどうですか\n",
+       "2    Bob        ä»æ¥ã¯ã©ãã§ãã\n",
        "3    Bob              Ça va bien, merci.\n",
        "4  Clara              ¡Nos vemos mañana!\n",
        "5  David              Ich hÃ¤tte Hunger."
       ]
      },
-     "execution_count": 187,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -449,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": 31,
    "id": "98633b5e-957c-4f2b-813f-208fbed6d855",
    "metadata": {},
    "outputs": [],
@@ -457,12 +449,12 @@
     "mistype = Mistype({\"mistype_dtype\": \"float64\"})\n",
     "ecar = ECAR()\n",
     "df_mistype = pd.DataFrame({\"a\": [1, 2, 3], \"b\": [\"blau\", \"gelb\", \"blau\"]})\n",
-    "df_corrupted, error_mask = create_errors(df_mistype, \"a\", 0.5, ecar, mistype)"
+    "df_corrupted, error_mask = low_level.create_errors(df_mistype, \"a\", 0.5, ecar, mistype)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": 32,
    "id": "a7d421e5-1103-4cde-849b-adb689043081",
    "metadata": {},
    "outputs": [
@@ -494,7 +486,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
        "      <td>blau</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -504,7 +496,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>3</td>\n",
+       "      <td>3.0</td>\n",
        "      <td>blau</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -513,12 +505,12 @@
       ],
       "text/plain": [
        "     a     b\n",
-       "0  1.0  blau\n",
+       "0    1  blau\n",
        "1    2  gelb\n",
-       "2    3  blau"
+       "2  3.0  blau"
       ]
      },
-     "execution_count": 163,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -537,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 33,
    "id": "dff2611e-b16b-4104-ba1d-4696a18c8330",
    "metadata": {},
    "outputs": [],
@@ -545,12 +537,12 @@
     "data = {\"A\": [\"apple\", \"banana\", \"cherry\", \"pineapple\"], \"B\": [\"red apple\", \"yellow banana\", \"dark cherry\", \"blue pineapple\"], \"C\": [10, 20, 30, 40]}\n",
     "df_permutate = pd.DataFrame(data)\n",
     "permutate = Permutate({\"permutation_separator\": \" \", \"permutation_automation_pattern\": \"fixed\"})\n",
-    "df_corrupted, error_mask = create_errors(df_permutate, \"B\", 1.0, ecar, permutate)"
+    "df_corrupted, error_mask = low_level.create_errors(df_permutate, \"B\", 1.0, ecar, permutate)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 34,
    "id": "1221cb45-2f54-4167-8ebb-26b4f6723555",
    "metadata": {},
    "outputs": [
@@ -617,7 +609,7 @@
        "3  pineapple  pineapple blue  40"
       ]
      },
-     "execution_count": 170,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -636,19 +628,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 35,
    "id": "92c3a871-3078-4552-b9e6-d583e36e2ec2",
    "metadata": {},
    "outputs": [],
    "source": [
     "mojibake = Mojibake()\n",
     "df_mojibake = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [\"Ente\", \"Haus\", \"Grünfelder Straße 17, 13357 Öppeln\"]})\n",
-    "df_corrupted, error_mask = create_errors(df_mojibake, \"b\", 1.0, ecar, mojibake)"
+    "df_corrupted, error_mask = low_level.create_errors(df_mojibake, \"b\", 1.0, ecar, mojibake)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 36,
    "id": "288759e4-f634-49d6-a285-deb0e0abf999",
    "metadata": {},
    "outputs": [
@@ -704,7 +696,7 @@
        "2  2  Grnfelder Strae 17, 13357 ppeln"
       ]
      },
-     "execution_count": 172,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -723,19 +715,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 37,
    "id": "8f5fa21b-0af8-43ae-9ac4-daa7c09c592a",
    "metadata": {},
    "outputs": [],
    "source": [
     "butterfinger = Butterfinger()\n",
     "df_butterfinger = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [\"Entspannung\", \"Genugtuung\", \"Ausgeglichenheit\"]})\n",
-    "df_corrupted, error_mask = create_errors(df_butterfinger, \"b\", 1.0, ecar, butterfinger)"
+    "df_corrupted, error_mask = low_level.create_errors(df_butterfinger, \"b\", 1.0, ecar, butterfinger)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 38,
    "id": "5fb3f20d-8e30-47fa-aa8d-aeb541264b81",
    "metadata": {},
    "outputs": [
@@ -768,17 +760,17 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>0</td>\n",
-       "      <td>Entspannunh</td>\n",
+       "      <td>Entspannujg</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>1</td>\n",
-       "      <td>G3nugtuung</td>\n",
+       "      <td>Genigtuung</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>2</td>\n",
-       "      <td>Qusgeglichenheit</td>\n",
+       "      <td>Ausgeglichenbeit</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -786,12 +778,12 @@
       ],
       "text/plain": [
        "   a                 b\n",
-       "0  0       Entspannunh\n",
-       "1  1        G3nugtuung\n",
-       "2  2  Qusgeglichenheit"
+       "0  0       Entspannujg\n",
+       "1  1        Genigtuung\n",
+       "2  2  Ausgeglichenbeit"
       ]
      },
-     "execution_count": 174,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -810,19 +802,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 39,
    "id": "53d9ebc6-7e12-4736-9734-babf114fa479",
    "metadata": {},
    "outputs": [],
    "source": [
     "wrong_unit = WrongUnit({\"wrong_unit_scaling\": lambda x: x / 1000})\n",
     "df_wrong_unit = pd.DataFrame({\"a\": [0, 1, 2], \"b\": [40, 50, 60]})\n",
-    "df_corrupted, error_mask = create_errors(df_wrong_unit, 1, 1.0, ecar, wrong_unit)"
+    "df_corrupted, error_mask = low_level.create_errors(df_wrong_unit, 1, 1.0, ecar, wrong_unit)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 40,
    "id": "656082b2-8cac-495a-aa59-eb662888cfc5",
    "metadata": {},
    "outputs": [
@@ -878,7 +870,7 @@
        "2  2  0.06"
       ]
      },
-     "execution_count": 176,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -897,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 41,
    "id": "6332c825-5cf3-421c-bb2e-f03cb55c34e6",
    "metadata": {},
    "outputs": [],
@@ -905,12 +897,12 @@
     "mislabel = Mislabel()\n",
     "df_mislabel = pd.DataFrame({\"a\": [1, 2, 3], \"b\": [\"blau\", \"gelb\", \"blau\"]})\n",
     "df_mislabel[\"b\"] = df_mislabel[\"b\"].astype(\"category\")\n",
-    "df_corrupted, error_mask = create_errors(df_mislabel, \"b\", 1.0, ecar, mislabel)"
+    "df_corrupted, error_mask = low_level.create_errors(df_mislabel, \"b\", 1.0, ecar, mislabel)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 42,
    "id": "8f064b77-b988-4c60-8363-42f93c90439c",
    "metadata": {},
    "outputs": [
@@ -966,7 +958,7 @@
        "2  3  gelb"
       ]
      },
-     "execution_count": 178,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -985,19 +977,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 43,
    "id": "5a0b6f34-6d5d-4e3a-9cd3-295fe2b0f1bd",
    "metadata": {},
    "outputs": [],
    "source": [
     "missing = MissingValue()\n",
     "df_missing = pd.DataFrame({\"a\": [1, 2, 3], \"b\": [\"blau\", \"gelb\", \"blau\"]})\n",
-    "df_corrupted, error_mask = create_errors(df_missing, \"b\", 1.0, ecar, missing)"
+    "df_corrupted, error_mask = low_level.create_errors(df_missing, \"b\", 1.0, ecar, missing)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 44,
    "id": "73e37424-6433-42ce-b85e-58c5510c48c9",
    "metadata": {},
    "outputs": [
@@ -1053,13 +1045,238 @@
        "2  3  None"
       ]
      },
-     "execution_count": 180,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df_corrupted"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4855fd4-dc17-48b0-9deb-9c6a51245e3c",
+   "metadata": {},
+   "source": [
+    "## Error Generation APIs\n",
+    "There are three APIs available to generate errors:\n",
+    "- Low Level API `api.low_level`\n",
+    "- Mid Level API `api.mid_level`\n",
+    "- High Level API`api.high_level` (not implemented yet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d8918e0-a2f4-48e3-9fbb-f70525d4d82e",
+   "metadata": {},
+   "source": [
+    "### Low Level API\n",
+    "The Low Level API is used to apply single error-models to a table, as demonstrated in the examples above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "378c6922-9784-4697-80d0-7ed2e4e5c168",
+   "metadata": {},
+   "source": [
+    "### Mid Level API\n",
+    "The Mid Level API allows the user to apply several error-models to one table.\n",
+    "It prevents conflicting error insertions from happening and ensures that as many errors as generated as the user required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "ff1393bf-2ac6-41bc-a341-a384b74aad5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_mid_level = pd.DataFrame(\n",
+    "    {\n",
+    "        \"typist\": [\"Alice\", \"Alice\", \"Alice\", \"Bob\", \"Bob\", \"Bob\"],\n",
+    "        \"book_title\": [\"To Kill a Mockingbird\", \"1984\", \"Pride and Prejudice\", \"The Great Gatsby\", \"Moby-Dick\", \"The Catcher in the Rye\"],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "config = MidLevelConfig(\n",
+    "    {\n",
+    "        \"typist\": [ErrorModel(ENAR(), MissingValue(), 0.5)],\n",
+    "        \"book_title\": [ErrorModel(EAR(condition_to_column=\"typist\"), Butterfinger(), 0.5)],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "df_corrupt, error_mask = mid_level.create_errors(df_mid_level, config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "63f1e8e0-68ae-4151-8c2b-2c7e69bee3ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>typist</th>\n",
+       "      <th>book_title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Alice</td>\n",
+       "      <td>To Kill a Mockingbird</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Alice</td>\n",
+       "      <td>2984</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>None</td>\n",
+       "      <td>Pride anr Prejudice</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>None</td>\n",
+       "      <td>The Great Gatwby</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>None</td>\n",
+       "      <td>Moby-Dick</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Bob</td>\n",
+       "      <td>The Catcher in the Rye</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  typist              book_title\n",
+       "0  Alice   To Kill a Mockingbird\n",
+       "1  Alice                    2984\n",
+       "2   None     Pride anr Prejudice\n",
+       "3   None        The Great Gatwby\n",
+       "4   None               Moby-Dick\n",
+       "5    Bob  The Catcher in the Rye"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_corrupt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "b7553e47-dac9-4a01-aa27-f64f3d5464a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>typist</th>\n",
+       "      <th>book_title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   typist  book_title\n",
+       "0   False       False\n",
+       "1   False        True\n",
+       "2    True        True\n",
+       "3    True        True\n",
+       "4    True       False\n",
+       "5   False       False"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "error_mask"
    ]
   }
  ],


### PR DESCRIPTION
This commit adds the mid-level API to `error_generation`. It can be used to apply multiple triples of (error_mechanism, error_type, error_rate) to a single table and manages conflicts that can emerge in the scenario.

I'm not super happy with the implementation - ideally, it would internally use the low-level API, which it currently is not. That's not so elegant. However, the current approach works, and I'm out of time to make things nicer.